### PR TITLE
Fix: SVG :class not working

### DIFF
--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -19,7 +19,7 @@ export class Attributes {
     this.base = base
     this.dynamicAttributes = []
     this.childClone = null
-    this.initialState = { className: this.base.element.className }
+    this.initialState = { classList: this.base.element.classList }
 
     this._getDynamicAttributes()
   }
@@ -33,10 +33,6 @@ export class Attributes {
       if (!this.dynamicAttributes.includes(attr.name))
         this.dynamicAttributes.push(attr.name)
     }
-  }
-
-  get baseClasses() {
-    return this.initialState.className.split(' ')
   }
 
   async evaluate() {
@@ -69,10 +65,12 @@ export class Attributes {
     const expr = this.base.element.getAttribute(':class')
     if (!expr) return
 
-    this.base.element.className = await this.base._interpret(expr, {
-      base: this.baseClasses,
+    const updatedClassNames = await this.base._interpret(expr, {
+      base: this.initialState.classList,
       isClass: true,
     })
+
+    this.base.element.setAttribute('class', updatedClassNames)
   }
 
   async evaluateText() {


### PR DESCRIPTION
## Description

For other DOM element `className` is a string, but for SVG it's an `SVGAnimatedString` object. With this said, I replaced how we fetch and set className to use the `classList` instead for fetching, and `setAttribute('class', value)` for setting the class name.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.10.2a0246a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.1-canary.10.2a0246a.0
  # or 
  yarn add tonic-minijs@1.0.1-canary.10.2a0246a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
