### PR TITLE
Feat: Key Events - Key Modifiers

### DIFF
--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -1,6 +1,6 @@
 import { Events } from './events'
 import { escapeHTML } from '../helpers/sanitize'
-import { dashToCamelCase } from '../helpers/strings'
+import { kebabToCamelCase } from '../helpers/strings'
 
 export class Attributes {
   static CUSTOM_ATTRIBUTES = [
@@ -22,7 +22,7 @@ export class Attributes {
     const [nativeAttr] = attribute.replace(':', '').split('.')
 
     if (nativeAttr.startsWith('data-')) return true
-    if (element[dashToCamelCase(nativeAttr)] === undefined) return false
+    if (element[kebabToCamelCase(nativeAttr)] === undefined) return false
 
     return true
   }
@@ -156,7 +156,7 @@ export class Attributes {
 
       try {
         const newValue = await this.base._interpret(expr)
-        const nativeAttr = dashToCamelCase(attr.slice(1))
+        const nativeAttr = kebabToCamelCase(attr.slice(1))
 
         if (attr.startsWith(':data-')) {
           if (

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -1,3 +1,5 @@
+import { camelToKebabCase } from '../helpers/strings'
+
 const ELEMENTS = [
   'div',
   'a',
@@ -15,17 +17,34 @@ const ELEMENTS = [
 ]
 
 const SPECIAL_KEYS = ['ctrl', 'meta', 'alt', 'shift']
+const DIRECTION_KEYS = ['up', 'down', 'left', 'right']
 
 function mapKey(keycode, key) {
-  if (keycode.startsWith('Key')) return keycode.slice(3).toLowerCase()
-  if (keycode.startsWith('Digit')) return keycode.slice(5).toLowerCase()
-  if (keycode.startsWith('Numpad')) return keycode.slice(6).toLowerCase()
-  if (keycode.startsWith('Arrow')) return keycode.slice(5).toLowerCase()
-  if (keycode.startsWith('Meta')) return 'meta'
-  if (keycode.startsWith('Alt')) return 'alt'
-  if (keycode.startsWith('Control')) return 'ctrl'
-  if (keycode.startsWith('Shift')) return 'shift'
-  return keycode.toLowerCase()
+  if (keycode.startsWith('Key')) return [keycode.slice(3).toLowerCase()]
+  if (keycode.startsWith('Digit')) return [keycode.slice(5).toLowerCase()]
+  if (keycode.startsWith('Numpad')) return [keycode.slice(6).toLowerCase()]
+  if (keycode.startsWith('Arrow')) return [keycode.slice(5).toLowerCase()]
+  if (keycode.startsWith('Meta')) {
+    const direction = keycode.slice(4).toLowerCase()
+    if (direction.length) return ['meta', `meta-${direction}`]
+    return ['meta']
+  }
+  if (keycode.startsWith('Alt')) {
+    const direction = keycode.slice(3).toLowerCase()
+    if (direction.length) return ['alt', `alt-${direction}`]
+    return ['alt']
+  }
+  if (keycode.startsWith('Control')) {
+    const direction = keycode.slice(7).toLowerCase()
+    if (direction.length) return ['ctrl', `ctrl-${direction}`]
+    return ['ctrl']
+  }
+  if (keycode.startsWith('Shift')) {
+    const direction = keycode.slice(5).toLowerCase()
+    if (direction.length) return ['shift', `shift-${direction}`]
+    return ['shift']
+  }
+  return [camelToKebabCase(keycode).toLowerCase()]
 }
 
 export class Events {
@@ -229,7 +248,13 @@ export class Events {
         const [specialKeys, normalKeys] = keycodes.reduce(
           ([special, normal], key) => {
             const lowerKey = key.toLowerCase()
-            if (SPECIAL_KEYS.includes(lowerKey)) {
+
+            const [specialKey, directionKey] = lowerKey.split('-')
+
+            if (
+              SPECIAL_KEYS.includes(specialKey) &&
+              (directionKey == null || DIRECTION_KEYS.includes(directionKey))
+            ) {
               special.push(lowerKey)
             } else {
               normal.push(lowerKey)
@@ -260,11 +285,24 @@ export class Events {
 
     const ctx = this
 
-    const areKeysPressed = (e, keycodes) =>
-      keycodes.normalKeys.every((key) => ctx.keysPressed[key]) &&
-      keycodes.specialKeys.every(
-        (key) => e[`${key}Key`] || ctx.keysPressed[key]
+    const areKeysPressed = (e, keycodes) => {
+      return (
+        keycodes.normalKeys.every((key) => {
+          const [_, directionKey] = key.split('-')
+
+          if (directionKey) return ctx.keysPressed[key]
+
+          return ctx.keysPressed[key]
+        }) &&
+        keycodes.specialKeys.every((key) => {
+          const [_, directionKey] = key.split('-')
+
+          if (directionKey) return ctx.keysPressed[key]
+
+          return e[`${key}Key`] || ctx.keysPressed[key]
+        })
       )
+    }
 
     const handleKeyPress = (e) => {
       if (e.target !== el) return
@@ -280,7 +318,12 @@ export class Events {
         })
       }
 
-      ctx.keysPressed[mapKey(e.code, e.key)] = e.type == 'keydown'
+      const pressedKeys = mapKey(e.code, e.key)
+      const isPressed = e.type === 'keydown'
+
+      pressedKeys.forEach((key) => {
+        ctx.keysPressed[key] = isPressed
+      })
 
       if (e.type === 'keydown') {
         const keyDownEvents = keyEvents.filter(

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -16,6 +16,18 @@ const ELEMENTS = [
 
 const SPECIAL_KEYS = ['ctrl', 'meta', 'alt', 'shift']
 
+function mapKey(keycode, key) {
+  if (keycode.startsWith('Key')) return keycode.slice(3).toLowerCase()
+  if (keycode.startsWith('Digit')) return keycode.slice(5).toLowerCase()
+  if (keycode.startsWith('Numpad')) return keycode.slice(6).toLowerCase()
+  if (keycode.startsWith('Arrow')) return keycode.slice(5).toLowerCase()
+  if (keycode.startsWith('Meta')) return 'meta'
+  if (keycode.startsWith('Alt')) return 'alt'
+  if (keycode.startsWith('Control')) return 'ctrl'
+  if (keycode.startsWith('Shift')) return 'shift'
+  return keycode.toLowerCase()
+}
+
 export class Events {
   static CUSTOM_KEY_EVENTS = [':keyup', ':keydown', ':keypress']
   static CUSTOM_EVENTS = [
@@ -51,6 +63,11 @@ export class Events {
     return (
       Events.validEvents.includes(event) ||
       Events.CUSTOM_KEY_EVENTS.some((key) => event.startsWith(key + '.'))
+    )
+  }
+  static isKeyEvent(attr) {
+    return Events.CUSTOM_KEY_EVENTS.some(
+      (key) => attr.startsWith(key + '.') || attr === key
     )
   }
 
@@ -100,7 +117,7 @@ export class Events {
         (key) => attr.name.startsWith(key + '.') || attr.name === key
       )
 
-      if (isKeyEvent) {
+      if (Events.isKeyEvent(attr.name)) {
         this.setKeyEvent(attr.name)
       } else if (!Events.CUSTOM_EVENTS.includes(attr.name)) {
         this.setEvent(attr.name)
@@ -195,6 +212,7 @@ export class Events {
     })
   }
 
+  // ! FIX: Update handling for multiple key events on same elemnt, should only add one event listener
   setKeyEvent(attr) {
     const [event, ...keycodes] = attr.split('.')
 
@@ -205,12 +223,18 @@ export class Events {
     if (!el.hasAttribute(attr)) return
     if (this.listener[attr]) this.disposeEvent(attr)
 
-    const specialKeys = keycodes.filter((key) =>
-      SPECIAL_KEYS.includes(key.toLowerCase())
+    const [specialKeys, normalKeys] = keycodes.reduce(
+      ([special, normal], key) => {
+        const lowerKey = key.toLowerCase()
+        if (SPECIAL_KEYS.includes(lowerKey)) {
+          special.push(lowerKey)
+        } else {
+          normal.push(lowerKey)
+        }
+        return [special, normal]
+      },
+      [[], []]
     )
-    const normalKeys = keycodes
-      .filter((key) => !SPECIAL_KEYS.includes(key.toLowerCase()))
-      .map((key) => key.toLowerCase())
 
     this.listener[attr] = []
     const ctx = this
@@ -219,18 +243,6 @@ export class Events {
     const areKeysPressed = (e) =>
       normalKeys.every((key) => ctx.keysPressed[key]) &&
       specialKeys.every((key) => e[`${key}Key`])
-
-    const mapKey = (keycode, key) => {
-      if (keycode.startsWith('Key')) return keycode.slice(3).toLowerCase()
-      if (keycode.startsWith('Digit')) return keycode.slice(5).toLowerCase()
-      if (keycode.startsWith('Numpad')) return keycode.slice(6).toLowerCase()
-      if (keycode.startsWith('Arrow')) return keycode.slice(5).toLowerCase()
-      if (keycode.startsWith('Meta')) return 'meta'
-      if (keycode.startsWith('Alt')) return 'alt'
-      if (keycode.startsWith('Control')) return 'ctrl'
-      if (keycode.startsWith('Shift')) return 'shift'
-      return keycode.toLowerCase()
-    }
 
     if (keycodes.length) {
       const handleKeyPress = (e) => {
@@ -264,7 +276,6 @@ export class Events {
           el,
           eventName: nativeEventName,
           event: (e) => {
-            console.log(e)
             if (e.target !== el) return
             if (!areKeysPressed(e)) return
             this.evaluate(attr)

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -262,7 +262,9 @@ export class Events {
 
     const areKeysPressed = (e, keycodes) =>
       keycodes.normalKeys.every((key) => ctx.keysPressed[key]) &&
-      keycodes.specialKeys.every((key) => e[`${key}Key`])
+      keycodes.specialKeys.every(
+        (key) => e[`${key}Key`] || ctx.keysPressed[key]
+      )
 
     const handleKeyPress = (e) => {
       if (e.target !== el) return

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -14,6 +14,8 @@ const ELEMENTS = [
   'canvas',
 ]
 
+const SPECIAL_KEYS = ['ctrl', 'meta', 'alt', 'shift']
+
 export class Events {
   static CUSTOM_KEY_EVENTS = [':keyup', ':keydown', ':keypress']
   static CUSTOM_EVENTS = [
@@ -55,6 +57,7 @@ export class Events {
   constructor(base) {
     this.base = base
     this.listener = {}
+    this.keysPressed = {}
     this.dynamicEvents = []
 
     this._getDynamicEvents()
@@ -93,8 +96,8 @@ export class Events {
       if (attr.name === ':load') return
       if (!Events.isValidEvent(attr.name)) return
 
-      const isKeyEvent = Events.CUSTOM_KEY_EVENTS.some((keyType) =>
-        attr.name.startsWith(keyType + '.')
+      const isKeyEvent = Events.CUSTOM_KEY_EVENTS.some(
+        (key) => attr.name.startsWith(key + '.') || attr.name === key
       )
 
       if (isKeyEvent) {
@@ -193,7 +196,7 @@ export class Events {
   }
 
   setKeyEvent(attr) {
-    const [event, keycode] = attr.split('.')
+    const [event, ...keycodes] = attr.split('.')
 
     if (!Events.CUSTOM_KEY_EVENTS.includes(event)) return
 
@@ -202,22 +205,81 @@ export class Events {
     if (!el.hasAttribute(attr)) return
     if (this.listener[attr]) this.disposeEvent(attr)
 
-    let key = keycode[0].toUpperCase() + keycode.slice(1)
+    const specialKeys = keycodes.filter((key) =>
+      SPECIAL_KEYS.includes(key.toLowerCase())
+    )
+    const normalKeys = keycodes
+      .filter((key) => !SPECIAL_KEYS.includes(key.toLowerCase()))
+      .map((key) => key.toLowerCase())
 
-    if (['up', 'down', 'left', 'right'].includes(keycode)) {
-      key = 'Arrow' + key
-    } else if (!['enter', 'space'].includes(keycode)) {
-      return
+    this.listener[attr] = []
+    const ctx = this
+    const nativeEventName = event.substring(1)
+
+    const areKeysPressed = (e) =>
+      normalKeys.every((key) => ctx.keysPressed[key]) &&
+      specialKeys.every((key) => e[`${key}Key`])
+
+    const mapKey = (keycode, key) => {
+      if (keycode.startsWith('Key')) return keycode.slice(3).toLowerCase()
+      if (keycode.startsWith('Digit')) return keycode.slice(5).toLowerCase()
+      if (keycode.startsWith('Numpad')) return keycode.slice(6).toLowerCase()
+      if (keycode.startsWith('Arrow')) return keycode.slice(5).toLowerCase()
+      if (keycode.startsWith('Meta')) return 'meta'
+      if (keycode.startsWith('Alt')) return 'alt'
+      if (keycode.startsWith('Control')) return 'ctrl'
+      if (keycode.startsWith('Shift')) return 'shift'
+      return keycode.toLowerCase()
     }
 
-    this.listener[attr] = {
-      el,
-      eventName: event.substring(1),
-      event: (e) => {
+    if (keycodes.length) {
+      const handleKeyPress = (e) => {
         if (e.target !== el) return
-        if (e.key !== key) return
-        this.evaluate(attr)
-      },
+
+        if (nativeEventName === 'keyup' && nativeEventName === e.type) {
+          if (areKeysPressed(e)) this.evaluate(attr)
+        }
+
+        ctx.keysPressed[mapKey(e.code, e.key)] = e.type == 'keydown'
+
+        if (nativeEventName === 'keydown' && nativeEventName === e.type) {
+          if (areKeysPressed(e)) this.evaluate(attr)
+        }
+      }
+
+      this.listener[attr].push({
+        el,
+        eventName: 'keydown',
+        event: handleKeyPress,
+      })
+
+      this.listener[attr].push({
+        el,
+        eventName: 'keyup',
+        event: handleKeyPress,
+      })
+
+      if (nativeEventName === 'keypress') {
+        this.listener[attr].push({
+          el,
+          eventName: nativeEventName,
+          event: (e) => {
+            console.log(e)
+            if (e.target !== el) return
+            if (!areKeysPressed(e)) return
+            this.evaluate(attr)
+          },
+        })
+      }
+    } else {
+      this.listener[attr].push({
+        el,
+        eventName: nativeEventName,
+        event: (e) => {
+          if (e.target !== el) return
+          this.evaluate(attr)
+        },
+      })
     }
   }
 

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -356,7 +356,7 @@ export class Events {
     if (keyPressEvents.length) {
       this.listener[listenerKey].push({
         el,
-        eventName: nativeEventName,
+        eventName: 'keypress',
         event: (e) => {
           if (e.target !== el) return
 

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -360,6 +360,7 @@ export class Events {
 
   disposeEvent(attr) {
     const listener = this.listener[attr]
+
     if (Array.isArray(listener)) {
       listener.forEach(({ el, eventName, event }) => {
         el.removeEventListener(eventName, event)
@@ -368,6 +369,9 @@ export class Events {
       const { el, eventName, event } = listener
       el.removeEventListener(eventName, event)
     }
+
+    if (this.listener[attr]) delete this.listener[attr]
+    if (attr === ':keyevents') this.keysPressed = {}
   }
 
   dispose() {

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -109,6 +109,8 @@ export class Events {
     const el = this.base.element
 
     // Other Event Bindings
+    const keyEvents = []
+
     Array.from(el.attributes).forEach((attr) => {
       if (attr.name === ':load') return
       if (!Events.isValidEvent(attr.name)) return
@@ -118,11 +120,13 @@ export class Events {
       )
 
       if (Events.isKeyEvent(attr.name)) {
-        this.setKeyEvent(attr.name)
+        keyEvents.push(attr.name)
       } else if (!Events.CUSTOM_EVENTS.includes(attr.name)) {
         this.setEvent(attr.name)
       }
     })
+
+    this.setKeyEvents(keyEvents)
 
     // Add event listeners
     Object.keys(this.listener).forEach((attr) => {
@@ -212,83 +216,109 @@ export class Events {
     })
   }
 
-  // ! FIX: Update handling for multiple key events on same elemnt, should only add one event listener
-  setKeyEvent(attr) {
-    const [event, ...keycodes] = attr.split('.')
-
-    if (!Events.CUSTOM_KEY_EVENTS.includes(event)) return
+  setKeyEvents(attrs) {
+    if (!attrs.length) return
 
     const el = this.base.element
 
-    if (!el.hasAttribute(attr)) return
-    if (this.listener[attr]) this.disposeEvent(attr)
+    const keyEvents = attrs
+      .map((attribute) => {
+        const [event, ...keycodes] = attribute.split('.')
+        const nativeEventName = event.substring(1)
 
-    const [specialKeys, normalKeys] = keycodes.reduce(
-      ([special, normal], key) => {
-        const lowerKey = key.toLowerCase()
-        if (SPECIAL_KEYS.includes(lowerKey)) {
-          special.push(lowerKey)
-        } else {
-          normal.push(lowerKey)
-        }
-        return [special, normal]
-      },
-      [[], []]
-    )
-
-    this.listener[attr] = []
-    const ctx = this
-    const nativeEventName = event.substring(1)
-
-    const areKeysPressed = (e) =>
-      normalKeys.every((key) => ctx.keysPressed[key]) &&
-      specialKeys.every((key) => e[`${key}Key`])
-
-    if (keycodes.length) {
-      const handleKeyPress = (e) => {
-        if (e.target !== el) return
-
-        if (nativeEventName === 'keyup' && nativeEventName === e.type) {
-          if (areKeysPressed(e)) this.evaluate(attr)
-        }
-
-        ctx.keysPressed[mapKey(e.code, e.key)] = e.type == 'keydown'
-
-        if (nativeEventName === 'keydown' && nativeEventName === e.type) {
-          if (areKeysPressed(e)) this.evaluate(attr)
-        }
-      }
-
-      this.listener[attr].push({
-        el,
-        eventName: 'keydown',
-        event: handleKeyPress,
-      })
-
-      this.listener[attr].push({
-        el,
-        eventName: 'keyup',
-        event: handleKeyPress,
-      })
-
-      if (nativeEventName === 'keypress') {
-        this.listener[attr].push({
-          el,
-          eventName: nativeEventName,
-          event: (e) => {
-            if (e.target !== el) return
-            if (!areKeysPressed(e)) return
-            this.evaluate(attr)
+        const [specialKeys, normalKeys] = keycodes.reduce(
+          ([special, normal], key) => {
+            const lowerKey = key.toLowerCase()
+            if (SPECIAL_KEYS.includes(lowerKey)) {
+              special.push(lowerKey)
+            } else {
+              normal.push(lowerKey)
+            }
+            return [special, normal]
           },
+          [[], []]
+        )
+
+        return {
+          attribute,
+          event,
+          nativeEventName,
+          keycodes: { specialKeys, normalKeys },
+        }
+      })
+
+      .filter(
+        ({ attribute, event }) =>
+          Events.isKeyEvent(event) && el.hasAttribute(attribute)
+      )
+
+    if (!keyEvents.length) return
+
+    const listenerKey = ':keyevents'
+    if (this.listener[listenerKey]) this.disposeEvent(listenerKey)
+    this.listener[listenerKey] = []
+
+    const ctx = this
+
+    const areKeysPressed = (e, keycodes) =>
+      keycodes.normalKeys.every((key) => ctx.keysPressed[key]) &&
+      keycodes.specialKeys.every((key) => e[`${key}Key`])
+
+    const handleKeyPress = (e) => {
+      if (e.target !== el) return
+
+      if (e.type === 'keyup') {
+        const keyUpEvents = keyEvents.filter(
+          (event) => event.nativeEventName === 'keyup'
+        )
+
+        keyUpEvents.forEach((keyEvent) => {
+          if (areKeysPressed(e, keyEvent.keycodes))
+            this.evaluate(keyEvent.attribute)
         })
       }
-    } else {
-      this.listener[attr].push({
+
+      ctx.keysPressed[mapKey(e.code, e.key)] = e.type == 'keydown'
+
+      if (e.type === 'keydown') {
+        const keyDownEvents = keyEvents.filter(
+          (event) => event.nativeEventName === 'keydown'
+        )
+
+        keyDownEvents.forEach((keyEvent) => {
+          if (areKeysPressed(e, keyEvent.keycodes))
+            this.evaluate(keyEvent.attribute)
+        })
+      }
+    }
+
+    this.listener[listenerKey].push({
+      el,
+      eventName: 'keydown',
+      event: handleKeyPress,
+    })
+
+    this.listener[listenerKey].push({
+      el,
+      eventName: 'keyup',
+      event: handleKeyPress,
+    })
+
+    const keyPressEvents = keyEvents.filter(
+      (event) => event.nativeEventName === 'keypress'
+    )
+
+    if (keyPressEvents.length) {
+      this.listener[listenerKey].push({
         el,
         eventName: nativeEventName,
         event: (e) => {
           if (e.target !== el) return
-          this.evaluate(attr)
+
+          keyPressEvents.forEach((keyEvent) => {
+            if (areKeysPressed(e, keyEvent.keycodes))
+              this.evaluate(keyEvent.attribute)
+          })
         },
       })
     }

--- a/lib/helpers/strings.js
+++ b/lib/helpers/strings.js
@@ -1,5 +1,12 @@
-export function dashToCamelCase(string) {
+export function kebabToCamelCase(string) {
   return string.replace(/-([a-z])/g, function (g) {
     return g[1].toUpperCase()
   })
+}
+
+export function camelToKebabCase(string) {
+  return string.replace(
+    /[A-Z]+(?![a-z])|[A-Z]/g,
+    ($, ofs) => (ofs ? '-' : '') + $.toLowerCase()
+  )
 }

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,11 @@ To set multiple reactive classes, you can use the `:class` attribute:
 
 You can create, use, and update state variables inside DOM events.
 
+Special variables are available in events:
+
+- `event` - the event object
+- `this` - the current element
+
 ### Native Events
 
 All native events are supported. You can use them like this:
@@ -177,6 +182,59 @@ These are the events added in by MiniJS:
   - triggers the `click` event.
   - triggers the `keyup.enter` and `keyup.space` events.
   - triggers the `touchstart` event.
+
+### Keyboard Events
+
+For keyboard events, you can listen to them using `:keyup`, `:keydown`, and `:keypress`:
+
+```html
+<input type="text" :keyup="console.log(event)" />
+```
+
+#### Key Modifiers
+
+You can also use key modifiers to listen to specific keys. Modifiers are appended to the event name using a dot:
+
+```html
+<input
+  type="text"
+  :keyup.up="console.log('keyup.up')"
+  :keydown.enter="console.log('keydown.enter')"
+/>
+```
+
+You can chain multiple key modifiers together:
+
+```html
+<input type="text" :keydown.slash.k="console.log('keydown.slash.k')" />
+```
+
+For key values that have multiple words like `BracketLeft`, except for arrow keys, kebab case is used:
+
+```html
+<input
+  type="text"
+  :keydown.bracket-left="console.log('keydown.bracket-left')"
+/>
+```
+
+The following are the available key modifiers:
+
+| Type                               | Key Value                          | Modifier                       | Usage                                               |
+| ---------------------------------- | ---------------------------------- | ------------------------------ | --------------------------------------------------- |
+| Digits (0-9)                       | Digit1, Digit2                     | 1, 2                           | :keyup.1, :keyup.2                                  |
+| Letters (A-Z, a-z)                 | KeyA, KeyB                         | a, b                           | :keyup.a, :keyup.b                                  |
+| Numpad (0-9)                       | Numpad1, Numpad2                   | 1, 2                           | :keyup.1, :keyup.2                                  |
+| Arrow Keys (up, down, left, right) | ArrowLeft, ArrowRight              | left, right                    | :keyup.left, :keyup.right                           |
+| Meta (left, right)                 | Meta, MetaLeft, MetaRight          | meta, meta-left, meta-right    | :keyup.meta, :keyup.meta-left, :keyup.meta-right    |
+| Alt (left, right)                  | Alt, AltLeft, AltRight             | alt, alt-left, alt-right       | :keyup.alt, :keyup.alt-left, :keyup.alt-right       |
+| Control (left, right)              | Control, ControlLeft, ControlRight | ctrl, ctrl-left, ctrl-right    | :keyup.ctrl, :keyup.ctrl-left, :keyup.ctrl-right    |
+| Shift (left, right)                | Shift, ShiftLeft, ShiftRight       | shift, shift-left, shift-right | :keyup.shift, :keyup.shift-left, :keyup.shift-right |
+| Symbols (., /, =, etc.)            | Period, BracketLeft, Slash         | period, bracket-left, slash    | :keyup.period, :keyup.bracket-left, :keyup.slash    |
+
+> Note: If you don't know the "name" of a symbol key, you can use the `console.log(event.code)` to see the key value. Example for the "Enter" key: `:keyup="console.log(event.code)"` will log "Enter". So you can use `:keyup.enter` to listen to the "Enter" key.
+
+---
 
 ## Statements
 


### PR DESCRIPTION
## Description

Keyboard Events

For keyboard events, you can listen to them using `:keyup`, `:keydown`, and `:keypress`:

```html
<input type="text" :keyup="console.log(event)" />
```

#### Key Modifiers

You can also use key modifiers to listen to specific keys. Modifiers are appended to the event name using a dot:

```html
<input
  type="text"
  :keyup.up="console.log('keyup.up')"
  :keydown.enter="console.log('keydown.enter')"
/>
```

You can chain multiple key modifiers together:

```html
<input type="text" :keydown.slash.k="console.log('keydown.slash.k')" />
```

For key values that have multiple words like `BracketLeft`, except for arrow keys, kebab case is used:

```html
<input
  type="text"
  :keydown.bracket-left="console.log('keydown.bracket-left')"
/>
```

The following are the available key modifiers:

| Type                               | Key Value                          | Modifier                       | Usage                                               |
| ---------------------------------- | ---------------------------------- | ------------------------------ | --------------------------------------------------- |
| Digits (0-9)                       | Digit1, Digit2                     | 1, 2                           | :keyup.1, :keyup.2                                  |
| Letters (A-Z, a-z)                 | KeyA, KeyB                         | a, b                           | :keyup.a, :keyup.b                                  |
| Numpad (0-9)                       | Numpad1, Numpad2                   | 1, 2                           | :keyup.1, :keyup.2                                  |
| Arrow Keys (up, down, left, right) | ArrowLeft, ArrowRight              | left, right                    | :keyup.left, :keyup.right                           |
| Meta (left, right)                 | Meta, MetaLeft, MetaRight          | meta, meta-left, meta-right    | :keyup.meta, :keyup.meta-left, :keyup.meta-right    |
| Alt (left, right)                  | Alt, AltLeft, AltRight             | alt, alt-left, alt-right       | :keyup.alt, :keyup.alt-left, :keyup.alt-right       |
| Control (left, right)              | Control, ControlLeft, ControlRight | ctrl, ctrl-left, ctrl-right    | :keyup.ctrl, :keyup.ctrl-left, :keyup.ctrl-right    |
| Shift (left, right)                | Shift, ShiftLeft, ShiftRight       | shift, shift-left, shift-right | :keyup.shift, :keyup.shift-left, :keyup.shift-right |
| Symbols (., /, =, etc.)            | Period, BracketLeft, Slash         | period, bracket-left, slash    | :keyup.period, :keyup.bracket-left, :keyup.slash    |

> Note: If you don't know the "name" of a symbol key, you can use the `console.log(event.code)` to see the key value. Example for the "Enter" key: `:keyup="console.log(event.code)"` will log "Enter". So you can use `:keyup.enter` to listen to the "Enter" key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `SPECIAL_KEYS` and `DIRECTION_KEYS` constant arrays for enhanced keyboard event handling.
	- Introduced `keysPressed` object property and `mapKey` function for keycode mapping.
	- Added support for keyboard events like `:keyup`, `:keydown`, and `:keypress` with key modifiers.
	- Provided a table of available key modifiers for different key types.
	- Included `camelToKebabCase` function for string format conversion.
- **Refactor**
	- Updated key handling logic within event listeners for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.13.d0074c8.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.1-canary.13.d0074c8.0
  # or 
  yarn add tonic-minijs@1.0.1-canary.13.d0074c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
