### PR TITLE
Refactor: :each with variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,50 @@
 
             // Where Tab
             regions = [
-              'Europe',
-              'Japan',
-              'United States',
-              'South Korea',
-              'Australia',
+              {
+                name: "I'm flexible",
+                image:
+                  'https://a0.muscache.com/pictures/f9ec8a23-ed44-420b-83e5-10ff1f071a13.jpg',
+                alt: 'Map of whole world',
+                value: '',
+              },
+              {
+                name: 'Europe',
+                image:
+                  'https://a0.muscache.com/im/pictures/7b5cf816-6c16-49f8-99e5-cbc4adfd97e2.jpg',
+                alt: 'Map of Europe',
+                value: 'Europe',
+              },
+              {
+                name: 'Japan',
+                image:
+                  'https://a0.muscache.com/im/pictures/26891a81-b9db-4a9c-8aab-63486b7e627c.jpg?im_w=320',
+                alt: 'Map of Japan',
+                value: 'Japan',
+              },
+              {
+                name: 'United States',
+                image:
+                  'https://a0.muscache.com/im/pictures/4e762891-75a3-4fe1-b73a-cd7e673ba915.jpg',
+                alt: 'Map of United States',
+                value: 'United States',
+              },
+              {
+                name: 'South Korea',
+                image:
+                  'https://a0.muscache.com/im/pictures/c193e77c-0b2b-4f76-8101-b869348d8fc4.jpg',
+                alt: 'Map of South Korea',
+                value: 'South Korea',
+              },
+              {
+                name: 'Australia',
+                image:
+                  'https://a0.muscache.com/im/pictures/42a1fb0f-214c-41ec-b9d7-135fbbdb8316.jpg',
+                alt: 'Map of Australia',
+                value: 'Australia',
+              },
             ]
+            regionNames = regions.map((region) => region.name)
             destinations = [
               'Boracay, Philippines',
               'Kyoto, Japan',
@@ -370,107 +408,33 @@
               <!-- Where: Search by Region -->
               <div
                 class="w-max p-6 bg-white rounded-3xl border border-gray-300 shadow"
-                :class="selectedTab === 'Where' && (regions.includes(destination) || !destination.length) ? '' : 'hidden'"
+                :class="selectedTab === 'Where' && (regionNames.includes(destination) || !destination.length) ? '' : 'hidden'"
               >
                 <div class="text-xs font-bold text-gray-900">
                   Search by region
                 </div>
 
-                <div class="my-6 grid grid-cols-3 gap-x-3 gap-y-6">
+                <div
+                  class="my-6 grid grid-cols-3 gap-x-3 gap-y-6"
+                  :each="region in regions"
+                >
                   <div class="flex flex-col gap-2">
                     <button
                       type="button"
                       class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = '';
+                      :click="destination = region.value;
                             selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
                     >
                       <img
                         class="touch-none h-full w-full"
-                        alt="Map of whole world"
-                        src="https://a0.muscache.com/pictures/f9ec8a23-ed44-420b-83e5-10ff1f071a13.jpg"
+                        :src="region.image"
+                        :alt="region.alt"
                       />
                     </button>
-                    <div class="text-sm text-gray-600">I'm flexible</div>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = 'Europe';
-                            selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
-                    >
-                      <img
-                        class="touch-none h-full w-full"
-                        alt="Map of Europe"
-                        src="https://a0.muscache.com/im/pictures/7b5cf816-6c16-49f8-99e5-cbc4adfd97e2.jpg"
-                      />
-                    </button>
-                    <div class="text-sm text-gray-600">Europe</div>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = 'Japan';
-                            selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
-                    >
-                      <img
-                        class="touch-none h-full w-full"
-                        alt="Map of Japan"
-                        src="https://a0.muscache.com/im/pictures/26891a81-b9db-4a9c-8aab-63486b7e627c.jpg?im_w=320"
-                      />
-                    </button>
-                    <div class="text-sm text-gray-600">Japan</div>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = 'United States';
-                            selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
-                    >
-                      <img
-                        class="touch-none h-full w-full"
-                        alt="Map of United States"
-                        src="https://a0.muscache.com/im/pictures/4e762891-75a3-4fe1-b73a-cd7e673ba915.jpg"
-                      />
-                    </button>
-                    <div class="text-sm text-gray-600">United States</div>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = 'South Korea';
-                            selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
-                    >
-                      <img
-                        class="touch-none h-full w-full"
-                        alt="Map of South Korea"
-                        src="https://a0.muscache.com/im/pictures/c193e77c-0b2b-4f76-8101-b869348d8fc4.jpg"
-                      />
-                    </button>
-                    <div class="text-sm text-gray-600">South Korea</div>
-                  </div>
-
-                  <div class="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      class="h-32 w-32 border border-gray-300 rounded-lg overflow-hidden hover:border-gray-900 focus:border-gray-900"
-                      :click="destination = 'Australia';
-                            selectedTab = whenSelectedTab === 'Dates' ? 'Check In' : 'When'"
-                    >
-                      <img
-                        class="touch-none h-full w-full"
-                        alt="Map of Australia"
-                        src="https://a0.muscache.com/im/pictures/42a1fb0f-214c-41ec-b9d7-135fbbdb8316.jpg"
-                      />
-                    </button>
-                    <div class="text-sm text-gray-600">Australia</div>
+                    <div
+                      class="text-sm text-gray-600"
+                      :text="region.name"
+                    ></div>
                   </div>
                 </div>
               </div>
@@ -478,7 +442,7 @@
               <!-- Where: Search Results -->
               <div
                 class="w-max py-6 bg-white rounded-3xl border border-gray-300 shadow"
-                :class="selectedTab === 'Where' && destination.length && !regions.includes(destination) ? '' : 'hidden'"
+                :class="selectedTab === 'Where' && destination.length && !regionNames.includes(destination) ? '' : 'hidden'"
               >
                 <ul :each="place in filteredDestinations">
                   <li
@@ -852,7 +816,7 @@
                 ></span>
               </a>
               <a
-                :class="activeTab == 'Team Members' ? 'text-gray-900' : 'text-gray-500' "
+                :class="activeTab == 'Team Members' ? 'text-gray-900' : 'text-gray-500'"
                 :click="activeTab = 'Team Members'"
                 class="hover:text-gray-700 group relative min-w-0 flex-1 overflow-hidden bg-white py-4 px-4 text-center text-sm font-medium hover:bg-gray-50 focus:z-10"
               >

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -212,7 +212,9 @@ export class Entity {
 
       try {
         const entity = new Entity(element)
-        entity.init()
+
+        if (entity.isInsideEachEl()) entity.dispose()
+        else entity.init()
       } catch (error) {
         console.error('Failed to initialize child entity:', error)
       }

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -42,6 +42,35 @@ export class Entity {
     return eachEl != null
   }
 
+  getEachEl() {
+    return this.getClosestEl(':each')
+  }
+
+  getEachItemEl() {
+    const eachItemEl = this.element.hasAttribute(':each.item')
+      ? this.element
+      : this.getClosestEl(':each.item')
+    return eachItemEl
+  }
+
+  isInsideEachItem() {
+    if (this.element.hasAttribute(':each')) return false
+
+    const eachItemEl = this.getEachItemEl()
+    return !(eachItemEl == null || eachItemEl?.[':each.item'])
+  }
+
+  isEachItem() {
+    return this.element.hasAttribute(':each.item')
+  }
+
+  isEachItemEvaluated() {
+    return (
+      this.element.getAttribute(':each.item') === 'true' ||
+      this.getClosestEl(':each.item')?.[':each.item'] === 'true'
+    )
+  }
+
   getClosestEl(attr) {
     attr = attr.replaceAll(':', '\\:').replaceAll('.', '\\.')
 
@@ -213,24 +242,34 @@ export class Entity {
       try {
         const entity = new Entity(element)
 
-        if (entity.isInsideEachEl()) {
-          const closestEachItem = entity.element.hasAttribute(':each.item')
-            ? entity
-            : entity.getClosestEl(':each.item')
+        const eachEl = entity.getEachEl()
+        const eachItemEl = entity.getEachItemEl()
+        const isEachItemAndInitialized =
+          eachEl != null && eachItemEl != null && eachEl.contains(eachItemEl)
 
-          const isEachItemInitialized =
-            closestEachItem === this.element ||
-            closestEachItem?.contains(this.element)
-
-          if (!isEachItemInitialized) continue
-          entity.dispose()
-        }
-
-        entity.init()
+        if (
+          eachEl == null ||
+          eachEl === entity.element ||
+          isEachItemAndInitialized
+        )
+          entity.init()
+        else entity.dispose()
       } catch (error) {
         console.error('Failed to initialize child entity:', error)
       }
     }
+
+    const eachItemEls = [...this.element.querySelectorAll('*[\\:each\\.item]')]
+    if (this.isEachItem()) eachItemEls.push(this.element)
+
+    eachItemEls.forEach((el) => {
+      el.setAttribute(':each.item', true)
+
+      Object.entries(el.dataset).forEach(([key, value]) => {
+        if (!key.startsWith('mini.each:')) return
+        delete el.dataset[key]
+      })
+    })
   }
 
   dispose() {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -213,8 +213,20 @@ export class Entity {
       try {
         const entity = new Entity(element)
 
-        if (entity.isInsideEachEl()) entity.dispose()
-        else entity.init()
+        if (entity.isInsideEachEl()) {
+          const closestEachItem = entity.element.hasAttribute(':each.item')
+            ? entity
+            : entity.getClosestEl(':each.item')
+
+          const isEachItemInitialized =
+            closestEachItem === this.element ||
+            closestEachItem?.contains(this.element)
+
+          if (!isEachItemInitialized) continue
+          entity.dispose()
+        }
+
+        entity.init()
       } catch (error) {
         console.error('Failed to initialize child entity:', error)
       }

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -11,6 +11,7 @@ export class Entity {
     this.variables = []
     this.id = this.generateEntityUUID()
 
+    this.state = {}
     this.events = new Events(this)
     this.attributes = new Attributes(this)
     MiniJS.state.addEntity(this)
@@ -22,7 +23,7 @@ export class Entity {
 
   setAsParent() {
     this.uuid = this.id
-    this.element.dataset.uuid = this.uuid
+    this.element.dataset['mini.uuid'] = this.uuid
   }
 
   isParent() {
@@ -31,6 +32,22 @@ export class Entity {
 
   isExists() {
     return document.documentElement.contains(this.element)
+  }
+
+  isInsideEachEl() {
+    if (this.element.hasAttribute(':each')) return false
+    if (this.element.hasAttribute(':each.item')) return true
+
+    const eachEl = this.getClosestEl(':each')
+    return eachEl != null
+  }
+
+  getClosestEl(attr) {
+    attr = attr.replaceAll(':', '\\:').replaceAll('.', '\\.')
+
+    return this.element.closest(
+      `*[${attr}]:not([data\\-mini\\.uuid='${this.uuid}'])`
+    )
   }
 
   getVariables() {
@@ -53,9 +70,12 @@ export class Entity {
 
       const filtered = [...referenced, ...member, ...assigned].filter(
         (value) => {
+          const variable = value.split('.')[0]
           const isNativeVariable =
-            typeof window[value] === 'function' &&
-            window[value].toString().indexOf('[native code]') === -1
+            typeof window[variable] === 'function' &&
+            window[variable].toString().indexOf('[native code]') === -1
+
+          if (variable in this.state) return false
 
           return !isNativeVariable
         }
@@ -80,10 +100,12 @@ export class Entity {
 
       const filtered = [...referenced, ...member, ...assigned].filter(
         (value) => {
+          const variable = value.split('.')[0]
           const isNativeVariable =
-            typeof window[value] === 'function' &&
-            window[value].toString().indexOf('[native code]') === -1
+            typeof window[variable] === 'function' &&
+            window[variable].toString().indexOf('[native code]') === -1
 
+          if (variable in this.state) return false
           return !isNativeVariable
         }
       )
@@ -154,22 +176,19 @@ export class Entity {
 
     engine.replace(ids, ['declared'])
 
-    return await engine.interpret(this)
+    return await engine.interpret(this, this.state)
   }
 
   getParent() {
     let currentElement = this.element
-    let parentNode = currentElement.parentNode
+    let parentNode = this.getClosestEl('data-mini.uuid')
 
-    while (!parentNode.dataset.uuid && parentNode !== document.body) {
-      currentElement = parentNode
-      parentNode = currentElement.parentNode
-    }
-
-    if (parentNode === document.body) return { id: 'EntityDocument' }
+    if (parentNode == null) return { id: 'EntityDocument' }
 
     const entities = Array.from(MiniJS.state.entities.values())
-    const entity = entities.find((e) => e.uuid == parentNode.dataset.uuid)
+    const entity = entities.find(
+      (e) => e.uuid == parentNode.dataset['mini.uuid']
+    )
 
     return entity
   }

--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -9,6 +9,7 @@ export class Attributes {
     ':value',
     ':checked',
     ':each',
+    ':each.item',
     ':parent',
   ]
   static FORBIDDEN_ATTRIBUTES = [':innerHTML', ':innerText']
@@ -30,9 +31,9 @@ export class Attributes {
   constructor(base) {
     this.base = base
     this.dynamicAttributes = []
-    this.childClone = null
     this.initialState = { classList: this.base.element.classList }
 
+    this.evaluateEachItem()
     this._getDynamicAttributes()
   }
 
@@ -78,11 +79,39 @@ export class Attributes {
     else if (attr === ':value') await this.evaluateValue()
     else if (attr === ':checked') await this.evaluateChecked()
     else if (attr === ':each') await this.evaluateEach()
+    else if (attr === ':each.item') await this.evaluateEachItem()
     else {
       if (!this.dynamicAttributes.includes(attr))
         this.dynamicAttributes.push(attr)
       await this.evaluateOtherAttributes()
     }
+  }
+
+  evaluateEachItem() {
+    if (this.base.element.hasAttribute(':each')) return
+
+    const eachItemEl = this.base.element.hasAttribute(':each.item')
+      ? this.base.element
+      : this.base.getClosestEl(':each.item')
+    if (eachItemEl == null) return
+
+    const state = {}
+
+    Object.entries(eachItemEl.dataset).forEach(([key, value]) => {
+      if (!key.startsWith('mini.each:')) return
+
+      const name = key.replace('mini.each:', '')
+
+      try {
+        this.base.state[name] = JSON.parse(value)
+        this.base.element.removeAttribute(key)
+      } catch (error) {
+        console.error(
+          `Failed to parse dataset.${key} for Entity#${this.base.id}:`,
+          error
+        )
+      }
+    })
   }
 
   evaluateParent() {
@@ -188,19 +217,20 @@ export class Attributes {
 
     try {
       const items = await this.base._interpret(iterable)
-      this.childClone ||= this.base.element.innerHTML
+      this.childClone ||= this.base.element.cloneNode(true).children
 
-      let newHTML = ''
+      this.base.element.innerHTML = ''
 
       items.forEach((item, index) => {
-        // TODO: Use the lexer to replace the variables
-        newHTML += this.childClone
-          .replaceAll(indexName, index)
-          .replaceAll(variable, `'${escapeHTML(item)}'`)
-      })
+        Array.from(this.childClone).forEach((child) => {
+          child.setAttribute(':each.item', true)
+          child.dataset[`mini.each:${variable}`] = JSON.stringify(item)
+          if (indexName) child.dataset[`mini.each:${indexName}`] = index
 
-      // ObserveDOM will be called for updated DOM to initialize the entities
-      this.base.element.innerHTML = newHTML
+          // ObserveDOM will be called for updated DOM to initialize the entities
+          this.base.element.appendChild(child.cloneNode(true))
+        })
+      })
     } catch (error) {
       this._handleError(':each', error)
     }

--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -88,14 +88,12 @@ export class Attributes {
   }
 
   evaluateEachItem() {
-    if (this.base.element.hasAttribute(':each')) return
-
-    const eachItemEl = this.base.element.hasAttribute(':each.item')
-      ? this.base.element
-      : this.base.getClosestEl(':each.item')
-    if (eachItemEl == null) return
+    if (!this.base.isInsideEachItem()) return
+    if (this.base.isEachItemEvaluated()) return
 
     const state = {}
+
+    const eachItemEl = this.base.getEachItemEl()
 
     Object.entries(eachItemEl.dataset).forEach(([key, value]) => {
       if (!key.startsWith('mini.each:')) return
@@ -104,7 +102,6 @@ export class Attributes {
 
       try {
         this.base.state[name] = JSON.parse(value)
-        this.base.element.removeAttribute(key)
       } catch (error) {
         console.error(
           `Failed to parse dataset.${key} for Entity#${this.base.id}:`,
@@ -223,7 +220,7 @@ export class Attributes {
 
       items.forEach((item, index) => {
         Array.from(this.childClone).forEach((child) => {
-          child.setAttribute(':each.item', true)
+          child.setAttribute(':each.item', false)
           child.dataset[`mini.each:${variable}`] = JSON.stringify(item)
           if (indexName) child.dataset[`mini.each:${indexName}`] = index
 

--- a/lib/generators/interpreter.js
+++ b/lib/generators/interpreter.js
@@ -35,10 +35,14 @@ export class Interpreter extends Lexer {
     super(code, options)
   }
 
-  async interpret(context) {
+  async interpret(context, _scope = {}) {
     const code = super.output()
-    // Needed for proxy variables, should be nice to pass only used variables instead of the proxyWindow
-    const scope = { ...DEFAULT_SCOPE, proxyWindow: MiniJS.window }
+
+    const scope = {
+      ...DEFAULT_SCOPE,
+      proxyWindow: MiniJS.window,
+      ..._scope,
+    }
 
     return await safeAsyncFunction(
       context.element,
@@ -55,10 +59,10 @@ export class ClassInterpreter extends Lexer {
     this._baseClasses = options.base ?? []
   }
 
-  async interpret(context) {
+  async interpret(context, _scope = {}) {
     const classNames = super.output()
-    // Needed for proxy variables, should be nice to pass only used variables instead of the proxyWindow
-    const scope = { ...DEFAULT_SCOPE, proxyWindow: MiniJS.window }
+
+    const scope = { ...DEFAULT_SCOPE, proxyWindow: MiniJS.window, ..._scope }
 
     let newClassNames = [...this._baseClasses]
 

--- a/lib/generators/lexer.js
+++ b/lib/generators/lexer.js
@@ -37,6 +37,12 @@ function setMemberIdentifier(node, members = []) {
   :click="const time = new Date().toLocaleTimeString())"
 - add support for:
   :click="const [a, b] = [1, 2]"
+- fix issue:
+  - regions.some(region => region.value === destination)
+  becoming:
+  - proxyWindow.regions.some(region => proxyWindow.region.value === proxyWindow.destination)
+  should be:
+  - proxyWindow.regions.some(region => region.value === proxyWindow.destination)
 */
 
 export class Lexer {

--- a/lib/main.js
+++ b/lib/main.js
@@ -91,7 +91,8 @@ const MiniJS = (() => {
       const elem = elems[i]
       if (elem.nodeType !== 1) continue
 
-      new Entity(elem)
+      const entity = new Entity(elem)
+      if (entity.isInsideEachEl()) entity.dispose()
     }
   }
 

--- a/readme.md
+++ b/readme.md
@@ -238,8 +238,40 @@ The following are the available key modifiers:
 
 ## Statements
 
-- `:each` (experimental!) - loop through an array and render a template for each item
-  - do not use in production
+### Each Statement
+
+The `:each` statement is used to loop through an array and render a template for each item.
+
+```html
+<script>
+  items = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4']
+</script>
+
+<ul :each="item in items">
+  <li :text="item"></li>
+</ul>
+
+<ul :each="item, index in items">
+  <li :text="item"></li>
+</ul>
+```
+
+You can also use complex variables for the `:each` statement:
+
+```html
+<script>
+  items = [
+    { name: 'Tag 1', id: 1 },
+    { name: 'Tag 2', id: 2 },
+    { name: 'Tag 3', id: 3 },
+    { name: 'Tag 4', id: 4 },
+  ]
+</script>
+
+<ul :each="item in items">
+  <li :text="item.name"></li>
+</ul>
+```
 
 ## Variables
 


### PR DESCRIPTION
## Description

- Fixed the `:each` to replace the variables properly instead of using a plain replace all.
- Add scoped-variables for each items.

## Usage

The `:each` statement is used to loop through an array and render a template for each item.

```html
<script>
  items = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4']
</script>

<ul :each="item in items">
  <li :text="item"></li>
</ul>

<ul :each="item, index in items">
  <li :text="item"></li>
</ul>
```

You can also use complex variables for the `:each` statement:

```html
<script>
  items = [
    { name: 'Tag 1', id: 1 },
    { name: 'Tag 2', id: 2 },
    { name: 'Tag 3', id: 3 },
    { name: 'Tag 4', id: 4 },
  ]
</script>

<ul :each="item in items">
  <li :text="item.name"></li>
</ul>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added `state` property to `Entity` class for improved state management.
    - Introduced methods for handling `':each.item'` attribute, enhancing data binding and DOM updates.
    - Expanded `interpret` method to accept `_scope` parameter for variable scope flexibility.
- **Bug Fixes**
    - Corrected value comparison logic within arrays to ensure accurate data handling.
- **Documentation**
    - Updated readme with examples and explanations of the `:each` statement for better developer understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.14.c08dc9f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.1-canary.14.c08dc9f.0
  # or 
  yarn add tonic-minijs@1.0.1-canary.14.c08dc9f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
