### PR TITLE
Feature: Support for Dynamically Inserted Scripts

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -5,9 +5,11 @@ import { Attributes } from './entity/attributes'
 import { State } from './state'
 
 export class Entity {
-  constructor(el) {
+  constructor(el, dynamicScripts = []) {
     this.element = el
     this.tagName = el.tagName
+    this.dynamicScripts = dynamicScripts
+
     this.variables = []
     this.id = this.generateEntityUUID()
 
@@ -227,6 +229,16 @@ export class Entity {
   }
 
   async init() {
+    const isScript = this.element.tagName === 'SCRIPT'
+
+    if (!isScript) {
+      const promises = this.dynamicScripts.map((script) =>
+        MiniJS.observer.dynamicScripts.get(script.dataset['mini.scriptId'])
+      )
+
+      await Promise.all(promises.map((promise) => promise.catch((e) => e)))
+    }
+
     this.getVariables()
     this.events.apply()
     await this.attributes.evaluate()
@@ -240,7 +252,7 @@ export class Entity {
       if (element.nodeType !== 1) continue
 
       try {
-        const entity = new Entity(element)
+        const entity = new Entity(element, this.dynamicScripts)
 
         const eachEl = entity.getEachEl()
         const eachItemEl = entity.getEachItemEl()

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -231,13 +231,7 @@ export class Entity {
   async init() {
     const isScript = this.element.tagName === 'SCRIPT'
 
-    if (!isScript) {
-      const promises = this.dynamicScripts.map((script) =>
-        MiniJS.observer.dynamicScripts.get(script.dataset['mini.scriptId'])
-      )
-
-      await Promise.all(promises.map((promise) => promise.catch((e) => e)))
-    }
+    if (!isScript) await MiniJS.observer.waitForScripts(this.dynamicScripts)
 
     this.getVariables()
     this.events.apply()

--- a/lib/generators/observer.js
+++ b/lib/generators/observer.js
@@ -1,7 +1,9 @@
+import { Entity } from '../entity'
+
 const MutationObserver =
   window.MutationObserver || window.WebKitMutationObserver
 
-export function observeDOM(obj, callback) {
+function observeDOM(obj, callback) {
   if (obj == null || obj.nodeType !== 1) return
 
   if (MutationObserver) {
@@ -25,5 +27,53 @@ export function observeDOM(obj, callback) {
       obj.removeEventListener('DOMNodeInserted', callback, false)
       obj.removeEventListener('DOMNodeRemoved', callback, false)
     }
+  }
+}
+
+export class Observer {
+  constructor(state) {
+    this.state = state
+    this.observer = null
+  }
+
+  init() {
+    this.observe(document.body, (mutation) => {
+      mutation.forEach((record) => {
+        if (
+          record.type === 'attributes' &&
+          record.attributeName.startsWith(':')
+        ) {
+          const entity = this.state.getEntityByElement(record.target)
+          if (!entity) return
+
+          const attr = record.attributeName
+
+          if (Events.isValidEvent(attr)) entity.events.applyEvent(attr)
+          else entity.attributes.evaluateAttribute(attr)
+        }
+
+        record.removedNodes.forEach((node) => {
+          if (node.nodeType !== 1) return
+          const entity = this.state.getEntityByElement(node)
+          entity?.dispose()
+        })
+
+        record.addedNodes.forEach((node) => {
+          if (node.nodeType !== 1) return
+          const entity = new Entity(node)
+          entity.init()
+          entity.initChildren()
+        })
+      })
+    })
+  }
+
+  observe(obj, callback) {
+    this.observer = observeDOM(obj, callback)
+  }
+
+  disconnect() {
+    if (this.observer == null) return
+    this.observer.disconnect()
   }
 }

--- a/lib/generators/observer.js
+++ b/lib/generators/observer.js
@@ -1,4 +1,5 @@
 import { Entity } from '../entity'
+import { Events } from '../entity/events'
 
 const MutationObserver =
   window.MutationObserver || window.WebKitMutationObserver
@@ -34,6 +35,7 @@ export class Observer {
   constructor(state) {
     this.state = state
     this.observer = null
+    this.dynamicScripts = new Map()
   }
 
   init() {
@@ -58,18 +60,71 @@ export class Observer {
           entity?.dispose()
         })
 
+        const dynamicScripts = this.waitForScripts(
+          Array.from(record.addedNodes)
+        )
+
         record.addedNodes.forEach((node) => {
           if (node.nodeType !== 1) return
-          const entity = new Entity(node)
-          entity.init()
-          entity.initChildren()
+
+          const entity = new Entity(node, dynamicScripts)
+          entity.init().then(() => {
+            entity.initChildren()
+          })
         })
       })
     })
   }
 
+  waitForScripts(nodes) {
+    const dynamicScripts = nodes
+      .reduce((acc, node) => {
+        if (node.nodeType !== 1) return acc
+        return [...acc, ...node.querySelectorAll('script')]
+      }, [])
+      .filter((node) => node.tagName === 'SCRIPT')
+
+    return dynamicScripts.map((script) => {
+      let resolve, reject
+      const promise = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      promise.resolve = resolve
+      promise.reject = reject
+
+      script.dataset['mini.scriptId'] =
+        script.dataset['mini.scriptId'] ?? this.generateUUID()
+
+      script.textContent += `\nMiniJS.observer.resolveScript()`
+      if (!this.dynamicScripts.get(script.dataset['mini.scriptId']))
+        this.dynamicScripts.set(script.dataset['mini.scriptId'], promise)
+
+      return script
+    })
+  }
+
+  resolveScript() {
+    const script = document.currentScript
+    const scriptID = script.dataset['mini.scriptId']
+    const promise = this.dynamicScripts.get(scriptID)
+    if (!promise) return
+
+    promise.resolve()
+
+    delete script.dataset['mini.scriptId']
+    script.textContent = script.textContent.replace(
+      '\nMiniJS.observer.resolveScript()',
+      ''
+    )
+  }
+
   observe(obj, callback) {
     this.observer = observeDOM(obj, callback)
+  }
+
+  generateUUID() {
+    return 'ScriptID' + Date.now() + Math.floor(Math.random() * 10000)
   }
 
   disconnect() {

--- a/lib/generators/observer.js
+++ b/lib/generators/observer.js
@@ -32,6 +32,8 @@ function observeDOM(obj, callback) {
 }
 
 export class Observer {
+  static SCRIPT_ID = 'mini.scriptId'
+
   constructor(state) {
     this.state = state
     this.observer = null
@@ -60,7 +62,7 @@ export class Observer {
           entity?.dispose()
         })
 
-        const dynamicScripts = this.waitForScripts(
+        const dynamicScripts = this.createScriptPromises(
           Array.from(record.addedNodes)
         )
 
@@ -76,7 +78,11 @@ export class Observer {
     })
   }
 
-  waitForScripts(nodes) {
+  observe(obj, callback) {
+    this.observer = observeDOM(obj, callback)
+  }
+
+  createScriptPromises(nodes) {
     const dynamicScripts = nodes
       .reduce((acc, node) => {
         if (node.nodeType !== 1) return acc
@@ -93,15 +99,22 @@ export class Observer {
       promise.resolve = resolve
       promise.reject = reject
 
-      script.dataset['mini.scriptId'] =
-        script.dataset['mini.scriptId'] ?? this.generateUUID()
+      script.dataset[Observer.SCRIPT_ID] =
+        script.dataset[Observer.SCRIPT_ID] ?? this.generateUUID()
 
       script.textContent += `\nMiniJS.observer.resolveScript()`
-      if (!this.dynamicScripts.get(script.dataset['mini.scriptId']))
-        this.dynamicScripts.set(script.dataset['mini.scriptId'], promise)
+      if (!this.dynamicScripts.get(script.dataset[Observer.SCRIPT_ID]))
+        this.dynamicScripts.set(script.dataset[Observer.SCRIPT_ID], promise)
 
       return script
     })
+  }
+
+  async waitForScripts(scripts) {
+    const promises = scripts.map((script) =>
+      this.dynamicScripts.get(script.dataset[Observer.SCRIPT_ID])
+    )
+    await Promise.all(promises.map((promise) => promise.catch((e) => e)))
   }
 
   resolveScript() {
@@ -117,10 +130,6 @@ export class Observer {
       '\nMiniJS.observer.resolveScript()',
       ''
     )
-  }
-
-  observe(obj, callback) {
-    this.observer = observeDOM(obj, callback)
   }
 
   generateUUID() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 import { Entity } from './entity'
 import { Lexer } from './generators/lexer'
-import { observeDOM } from './generators/observer'
+import { Observer } from './generators/observer'
 import { State } from './state'
 import { Events } from './entity/events'
 
@@ -9,6 +9,7 @@ let nativeProps = Object.getOwnPropertyNames(window)
 const MiniJS = (() => {
   let _debug = false
   const state = new State()
+  const observer = new Observer(state)
 
   async function init() {
     // Automatically initialize when the script is loaded
@@ -22,42 +23,10 @@ const MiniJS = (() => {
     _initializeGlobalVariables()
     Events.applyEvents()
     state.evaluate()
-    _listenToDOMChanges()
+    observer.init()
     const endTime = performance.now()
     const executionTime = endTime - startTime
     console.log(`MiniJS took ${executionTime}ms to run.`)
-  }
-
-  function _listenToDOMChanges() {
-    observeDOM(document.body, (mutation) => {
-      mutation.forEach((record) => {
-        if (
-          record.type === 'attributes' &&
-          record.attributeName.startsWith(':')
-        ) {
-          const entity = state.getEntityByElement(record.target)
-          if (!entity) return
-
-          const attr = record.attributeName
-
-          if (Events.isValidEvent(attr)) entity.events.applyEvent(attr)
-          else entity.attributes.evaluateAttribute(attr)
-        }
-
-        record.removedNodes.forEach((node) => {
-          if (node.nodeType !== 1) return
-          const entity = state.getEntityByElement(node)
-          entity?.dispose()
-        })
-
-        record.addedNodes.forEach((node) => {
-          if (node.nodeType !== 1) return
-          const entity = new Entity(node)
-          entity.init()
-          entity.initChildren()
-        })
-      })
-    })
   }
 
   function _setDebugMode() {
@@ -127,6 +96,9 @@ const MiniJS = (() => {
     },
     get state() {
       return state
+    },
+    get observer() {
+      return observer
     },
     tryFromLocal,
   }


### PR DESCRIPTION
## Description

- Other nodes will wait for the dynamically inserted scripts to be finish before evaluating its attributes.

For example, this list item is dynamically inserted into the DOM on a button click. the two script tags are evaluated first before the other items gets evaluated.

```html
<li>
  <script>
    months = [
      { name: 'April', id: 1 },
      { name: 'May', id: 2 },
      { name: 'June', id: 3 },
    ]
  </script>

  <script>
    choco = 'Test'
  </script>

  <ul :each="month, index in months">
    <li :text="`${month.name}'s months: ${month.id} ${choco}`"></li>
  </ul>
</li>
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.15.19aaccb.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.1-canary.15.19aaccb.0
  # or 
  yarn add tonic-minijs@1.0.1-canary.15.19aaccb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic script loading capabilities for enhanced flexibility in app behavior.
	- Added a new Observer class to efficiently monitor and respond to changes in the app's DOM.

- **Refactor**
	- Streamlined DOM observation by transitioning to a more robust and encapsulated Observer class approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->