### PR TITLE
Refactor: Group Variables (rename of Parent Variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,30 +340,26 @@ If you want to use the variable across an element's attributes and events, you c
 
 Like the example above, `:load` can be used to set the initial value of the variable.
 
-### Parent Element Variables
+### Group Variables
 
-Adding a `:parent` attribute to an element will allow you to access its variables from its children using `parent.` variables.
-
-A children's `parent.` variable is the same as the parent's `el.` variable.
+Adding a `:group` attribute to an element will allow you to access its variables from its children using `group.` variables.
 
 ```html
-<div id="accordion" class="accordion" :parent>
-  <!-- Parent Element -->
-
+<!-- Group Element -->
+<div id="accordion" class="accordion" :group>
   <!-- Children Elements -->
-  <!-- parent.variable == #accordion's el.variable -->
   <section
     class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
   >
     <button
-      :click="parent.activeSection = 'about'"
+      :click="group.activeSection = 'about'"
       class="cursor-pointer font-bold p-4"
     >
       About Us
     </button>
     <div
       class="p-4 pt-2 overflow-hidden hidden"
-      :class="parent.activeSection =='about' ? 'block' : 'hidden'"
+      :class="group.activeSection =='about' ? 'block' : 'hidden'"
     >
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
       eirmod.
@@ -374,14 +370,14 @@ A children's `parent.` variable is the same as the parent's `el.` variable.
     class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
   >
     <button
-      :click="parent.activeSection = 'contact'"
+      :click="group.activeSection = 'contact'"
       class="cursor-pointer font-bold p-4"
     >
       Contact Us
     </button>
     <div
       class="p-4 pt-2 overflow-hidden"
-      :class="parent.activeSection =='contact' ? 'block' : 'hidden'"
+      :class="group.activeSection =='contact' ? 'block' : 'hidden'"
     >
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
       eirmod.
@@ -390,22 +386,30 @@ A children's `parent.` variable is the same as the parent's `el.` variable.
 
   <section
     class="grid transition-all border-gray-300 border rounded hover:bg-gray-100"
-    :class="parent.activeSection =='team' ? 'active' : ''"
+    :class="group.activeSection =='team' ? 'active' : ''"
   >
     <button
-      :click="parent.activeSection = 'team'"
+      :click="group.activeSection = 'team'"
       class="cursor-pointer font-bold p-4"
     >
       Team 3
     </button>
     <div
       class="p-4 pt-2 overflow-hidden"
-      :class="parent.activeSection =='team' ? 'block' : 'hidden'"
+      :class="group.activeSection =='team' ? 'block' : 'hidden'"
     >
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
       eirmod.
     </div>
   </section>
+</div>
+```
+
+You can set the default value of the group variables in the `:group` directive:
+
+```html
+<div id="accordion" class="accordion" :group="activeSection = 'about'">
+  <!-- ... -->
 </div>
 ```
 

--- a/index.html
+++ b/index.html
@@ -1471,7 +1471,7 @@
           grid-template-rows: 0fr 1fr;
         }
       </style>
-      <div class="accordion" :group>
+      <div class="accordion" :group="activeSection = 'about'">
         <section
           class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
           :class="group.activeSection == 'about' ? 'active' : ''"

--- a/index.html
+++ b/index.html
@@ -1471,13 +1471,13 @@
           grid-template-rows: 0fr 1fr;
         }
       </style>
-      <div class="accordion" :parent>
+      <div class="accordion" :group>
         <section
           class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
-          :class="parent.activeSection == 'about' ? 'active' : ''"
+          :class="group.activeSection == 'about' ? 'active' : ''"
         >
           <a
-            :click="parent.activeSection='about'"
+            :click="group.activeSection = 'about'"
             class="cursor-pointer font-bold p-4"
           >
             About Us
@@ -1492,10 +1492,10 @@
 
         <section
           class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
-          :class="parent.activeSection =='contact' ? 'active' : ''"
+          :class="group.activeSection =='contact' ? 'active' : ''"
         >
           <a
-            :click="parent.activeSection='contact'"
+            :click="group.activeSection = 'contact'"
             class="cursor-pointer font-bold p-4"
           >
             Contact Us
@@ -1510,10 +1510,10 @@
 
         <section
           class="grid transition-all border-gray-300 border rounded hover:bg-gray-100"
-          :class="parent.activeSection =='team' ? 'active' : ''"
+          :class="group.activeSection =='team' ? 'active' : ''"
         >
           <a
-            :click="parent.activeSection='team'"
+            :click="group.activeSection = 'team'"
             class="cursor-pointer font-bold p-4"
           >
             Team 3

--- a/index.html
+++ b/index.html
@@ -1473,12 +1473,13 @@
       </style>
       <div class="accordion" :group="activeSection = 'about'">
         <section
-          class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
+          class="transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
           :class="group.activeSection == 'about' ? 'active' : ''"
         >
           <a
             :click="group.activeSection = 'about'"
             class="cursor-pointer font-bold p-4"
+            :aria-expanded="group.activeSection == 'about'"
           >
             About Us
           </a>
@@ -1491,12 +1492,13 @@
         </section>
 
         <section
-          class="grid transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
+          class="transition-all border-gray-300 border border-b-0 rounded hover:bg-gray-100"
           :class="group.activeSection =='contact' ? 'active' : ''"
         >
           <a
             :click="group.activeSection = 'contact'"
             class="cursor-pointer font-bold p-4"
+            :aria-expanded="group.activeSection == 'contact'"
           >
             Contact Us
           </a>
@@ -1509,11 +1511,12 @@
         </section>
 
         <section
-          class="grid transition-all border-gray-300 border rounded hover:bg-gray-100"
-          :class="group.activeSection =='team' ? 'active' : ''"
+          class="transition-all border-gray-300 border rounded hover:bg-gray-100"
+          :class="group.activeSection == 'team' ? 'active' : ''"
         >
           <a
             :click="group.activeSection = 'team'"
+            :aria-expanded="group.activeSection == 'team'"
             class="cursor-pointer font-bold p-4"
           >
             Team 3

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -23,15 +23,15 @@ export class Entity {
 
     if (this.base.debug) this.element.dataset.entityId = this.id
 
-    this.attributes.evaluateParent()
+    this.attributes.evaluateGroup()
   }
 
-  setAsParent() {
+  setAsGroup() {
     this.uuid = this.id
     this.element.dataset['mini.uuid'] = this.uuid
   }
 
-  isParent() {
+  isGroup() {
     return !!this.uuid
   }
 
@@ -143,7 +143,7 @@ export class Entity {
 
     this.variables.forEach((variable) => {
       if (State.isElState(variable)) {
-        this.setAsParent()
+        this.setAsGroup()
 
         if (window[this.id] == null) {
           window[this.id] = this.base.state.create({}, this.id)
@@ -151,26 +151,26 @@ export class Entity {
 
         this.base.state.addVariable(this.id, this.id)
 
-        if (variable !== 'el') {
+        if (variable !== State.EL_STATE) {
           const [_, varName] = variable.split('.')
           this.base.state.addEntityVariable(this.id, varName, this.id)
         }
-      } else if (State.isParentState(variable)) {
-        if (!this.parent) this.parent = this.getParent()
+      } else if (State.isGroupState(variable)) {
+        if (!this.group) this.group = this.getGroup()
 
-        // Cases where parent is not found:
-        // - an each item with a :parent directive being removed due to re-evaluation of :each attribute
-        if (this.parent == null) return
+        // Cases where group is not found:
+        // - an each item with a :group directive being removed due to re-evaluation of :each attribute
+        if (this.group == null) return
 
-        if (window[this.parent.id] == null) {
-          window[this.parent.id] = this.base.state.create({}, this.parent.id)
+        if (window[this.group.id] == null) {
+          window[this.group.id] = this.base.state.create({}, this.group.id)
         }
 
-        this.base.state.addVariable(this.parent.id, this.id)
+        this.base.state.addVariable(this.group.id, this.id)
 
-        if (variable !== 'parent') {
+        if (variable !== State.GROUP_STATE) {
           const [_, varName] = variable.split('.')
-          this.base.state.addEntityVariable(this.parent.id, varName, this.id)
+          this.base.state.addEntityVariable(this.group.id, varName, this.id)
         }
       } else if (typeof window[variable] === 'function') {
         this.variables.splice(this.variables.indexOf(variable), 1)
@@ -186,15 +186,14 @@ export class Entity {
     })
   }
 
-  getParent() {
-    let currentElement = this.element
-    let parentNode = this.getClosestEl('data-mini.uuid')
+  getGroup() {
+    const groupNode = this.getClosestEl('data-mini.uuid')
 
-    if (parentNode == null) return { id: 'EntityDocument' }
+    if (groupNode == null) return { id: 'EntityDocument' }
 
     const entities = Array.from(this.base.state.entities.values())
     const entity = entities.find(
-      (e) => e.uuid == parentNode.dataset['mini.uuid']
+      (e) => e.uuid == groupNode.dataset['mini.uuid']
     )
 
     return entity

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -14,6 +14,7 @@ export class Entity {
     this.dynamicScripts = dynamicScripts
 
     this.variables = []
+    this.groupVariables = []
     this.id = this.generateEntityUUID()
 
     this.state = {}
@@ -23,10 +24,13 @@ export class Entity {
 
     if (this.base.debug) this.element.dataset.entityId = this.id
 
-    this.attributes.evaluateGroup()
+    this.setAsGroup()
   }
 
   setAsGroup() {
+    if (!this.element.hasAttribute(':group')) return
+    if (this.isGroup()) return
+
     this.uuid = this.id
     this.element.dataset['mini.uuid'] = this.uuid
   }
@@ -117,7 +121,8 @@ export class Entity {
         return !(variable in this.state)
       })
 
-      this.variables.push(...identifiers)
+      if (name === ':group') this.groupVariables.push(...identifiers)
+      else this.variables.push(...identifiers)
     })
   }
 

--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -11,7 +11,7 @@ export class Attributes {
     ':checked',
     ':each',
     ':each.item',
-    ':parent',
+    ':group',
   ]
   static FORBIDDEN_ATTRIBUTES = [':innerHTML', ':innerText']
 
@@ -67,8 +67,8 @@ export class Attributes {
       // "this" is set under the interpreter as bind context
     }
 
-    if (this.base.parent)
-      ids.parent = `proxyWindow['${this.base.parent.id}${State.DISABLE_RE_RENDER_KEY}']`
+    if (this.base.group)
+      ids.group = `proxyWindow['${this.base.group.id}${State.DISABLE_RE_RENDER_KEY}']`
 
     engine.replace(ids)
 
@@ -93,7 +93,7 @@ export class Attributes {
 
   async evaluateAttribute(attr) {
     if (!Attributes.isValidAttribute(attr, this.base.element)) return
-    if (attr === ':parent') this.evaluateParent()
+    if (attr === ':group') this.evaluateGroup()
     else if (attr === ':class') await this.evaluateClass()
     else if (attr === ':text') await this.evaluateText()
     else if (attr === ':value') await this.evaluateValue()
@@ -131,10 +131,10 @@ export class Attributes {
     })
   }
 
-  evaluateParent() {
-    if (!this.base.element.hasAttribute(':parent')) return
-    if (this.base.isParent()) return
-    this.base.setAsParent()
+  evaluateGroup() {
+    if (!this.base.element.hasAttribute(':group')) return
+    if (this.base.isGroup()) return
+    this.base.setAsGroup()
   }
 
   async evaluateClass() {

--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -64,11 +64,14 @@ export class Attributes {
     const ids = {
       $: 'document-querySelector',
       el: `proxyWindow['${this.base.id}${State.DISABLE_RE_RENDER_KEY}']`,
+      group: this.base.group
+        ? `proxyWindow['${this.base.group.id}${
+            !options.isGroup ? State.DISABLE_RE_RENDER_KEY : ''
+          }']`
+        : undefined,
+      ...(options.ids || {}),
       // "this" is set under the interpreter as bind context
     }
-
-    if (this.base.group)
-      ids.group = `proxyWindow['${this.base.group.id}${State.DISABLE_RE_RENDER_KEY}']`
 
     engine.replace(ids)
 
@@ -93,7 +96,7 @@ export class Attributes {
 
   async evaluateAttribute(attr) {
     if (!Attributes.isValidAttribute(attr, this.base.element)) return
-    if (attr === ':group') this.evaluateGroup()
+    if (attr === ':group') await this.evaluateGroup()
     else if (attr === ':class') await this.evaluateClass()
     else if (attr === ':text') await this.evaluateText()
     else if (attr === ':value') await this.evaluateValue()
@@ -131,10 +134,31 @@ export class Attributes {
     })
   }
 
-  evaluateGroup() {
-    if (!this.base.element.hasAttribute(':group')) return
-    if (this.base.isGroup()) return
-    this.base.setAsGroup()
+  /*
+    :group is a special attribute that acts as an :load event
+    when it has a given expr. Unlike other attributes, state updates
+    inside :group will trigger re-renders.
+
+    NOTE: This should NOT be used in this.evaluate() because it will
+    trigger an infinite loop.
+  */
+  async evaluateGroup() {
+    if (!this.base.isGroup()) return
+
+    const expr = this.base.element.getAttribute(':group')
+    if (!expr) return
+
+    const ids = {}
+
+    this.base.groupVariables.forEach((variable) => {
+      ids[variable] = `proxyWindow['${this.base.id}'].${variable}`
+    })
+
+    try {
+      await this._interpret(expr, { isGroup: true, ids })
+    } catch (error) {
+      this._handleError(':group', expr, error)
+    }
   }
 
   async evaluateClass() {

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -425,19 +425,34 @@ export class Events {
     const expr = entity.element.getAttribute(attr)
     if (!expr) return
 
+    const EL_PREFIX = State.EL_STATE + '.'
     const elVariables = entity.variables
-      .filter((v) => v.startsWith('el.') && v !== 'el')
-      .map((v) => v.replace('el.', ''))
-    const variables = entity.variables.filter((v) => !v.startsWith('el.'))
+      .filter((v) => v.startsWith(EL_PREFIX) && v !== State.EL_STATE)
+      .map((v) => v.replace(EL_PREFIX, ''))
+
+    const GROUP_PREFIX = State.EL_STATE + '.'
+    const groupVariables = entity.variables
+      .filter((v) => v.startsWith(GROUP_PREFIX) && v !== State.GROUP_STATE)
+      .map((v) => v.replace(GROUP_PREFIX, ''))
+
+    const variables = entity.variables.filter(
+      (v) => !v.startsWith(EL_PREFIX) && !v.startsWith(GROUP_PREFIX)
+    )
 
     mini.state.attachVariableHelpers(variables)
     mini.state.attachVariableHelpers(elVariables, entity.id)
+
+    if (entity.group)
+      mini.state.attachVariableHelpers(groupVariables, entity.group.id)
 
     try {
       await this._interpret(expr)
 
       mini.state.attachVariableHelpers(variables)
       mini.state.attachVariableHelpers(elVariables, entity.id)
+
+      if (entity.group)
+        mini.state.attachVariableHelpers(groupVariables, entity.group.id)
     } catch (error) {
       if (!entity.isExists()) return
       console.error(
@@ -455,10 +470,10 @@ export class Events {
       // "this" is set under the interpreter as bind context
     }
 
-    if (this.base.parent) ids.parent = `proxyWindow['${this.base.parent.id}']`
+    if (this.base.group) ids.group = `proxyWindow['${this.base.group.id}']`
 
     this.base.variables.forEach((variable) => {
-      if (State.isElState(variable) || State.isParentState(variable)) return
+      if (State.isElState(variable) || State.isGroupState(variable)) return
 
       ids[variable] = `proxyWindow-${variable}`
     })

--- a/lib/generators/lexer.js
+++ b/lib/generators/lexer.js
@@ -1,6 +1,7 @@
 import { Parser } from 'acorn'
 import * as walk from 'acorn-walk'
 import escodegen from 'escodegen'
+import { State } from '../state'
 
 const FUNCTION_NODE_TYPES = [
   'FunctionDeclaration',
@@ -113,7 +114,7 @@ function getVariables(node) {
 export class Lexer {
   static debug = false
   static IGNORED_KEYS = ['event', 'window', 'document', 'console', 'Math']
-  static ENTITY_KEYS = ['el', 'parent']
+  static ENTITY_KEYS = [State.EL_STATE, State.GROUP_STATE]
 
   constructor(code) {
     this._code = code

--- a/lib/state.js
+++ b/lib/state.js
@@ -196,6 +196,7 @@ export class State {
 
   evaluate() {
     Array.from(this.entities.values()).forEach((entity) => {
+      entity.attributes.evaluateAttribute(':group')
       entity.attributes.evaluate()
     })
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -262,8 +262,8 @@ export class State {
     this.variables.delete(variable)
   }
 
-  disposeEntityVariable(groupID, variable) {
-    const key = `${groupID}.${variable}`
+  disposeEntityVariable(entityID, variable) {
+    const key = `${entityID}.${variable}`
     this.entityVariables.delete(key)
   }
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -4,7 +4,7 @@ import { Mini } from './main'
 export class State {
   static DISABLE_RE_RENDER_KEY = '_.'
   static EL_STATE = 'el'
-  static PARENT_STATE = 'parent'
+  static GROUP_STATE = 'group'
 
   static isLocalState(variable) {
     return variable[0] === '$'
@@ -16,10 +16,10 @@ export class State {
     )
   }
 
-  static isParentState(variable) {
+  static isGroupState(variable) {
     return (
-      variable.startsWith(State.PARENT_STATE + '.') ||
-      variable === State.PARENT_STATE
+      variable.startsWith(State.GROUP_STATE + '.') ||
+      variable === State.GROUP_STATE
     )
   }
 
@@ -82,8 +82,8 @@ export class State {
     this.variables.set(variable, [...new Set(variables), entityID])
   }
 
-  addEntityVariable(parentEntityID, variable, entityID) {
-    const key = `${parentEntityID}.${variable}`
+  addEntityVariable(groupID, variable, entityID) {
+    const key = `${groupID}.${variable}`
     const variables = this.entityVariables.get(key) || []
     this.entityVariables.set(key, [...new Set(variables), entityID])
   }
@@ -261,8 +261,8 @@ export class State {
     this.variables.delete(variable)
   }
 
-  disposeEntityVariable(parentEntityID, variable) {
-    const key = `${parentEntityID}.${variable}`
+  disposeEntityVariable(groupID, variable) {
+    const key = `${groupID}.${variable}`
     this.entityVariables.delete(key)
   }
 }


### PR DESCRIPTION
## Description

Changed functionality of `:parent` to be a `:group` directive:

```html
<div :group>
   <div :click=" group.selectedTab = 'about' "></div>
   <div :click=" group.selectedTab = 'contact' "></div>
</div>
```

For settings the default value, you can specify them under the `:group` directive:

```html
<div :group=" selectedTab = 'about' ">
   <div :click=" group.selectedTab = 'about' "></div>
   <div :click=" group.selectedTab = 'contact' "></div>
</div>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new syntax for accessing variables in child elements, changing from `:parent` to `:group`.
	- Added the ability to set default values for group variables using the `:group` directive.
- **Refactor**
	- Updated the logic for managing active sections in accordion components to use the new `group` object instead of `parent`.
	- Renamed and updated various internal methods and properties to align with the new `group` terminology, enhancing clarity and consistency.
- **Bug Fixes**
	- Fixed variable handling and state management issues by differentiating between group-specific and regular variables.
- **Documentation**
	- Updated README.md and index.html to reflect the changes in variable access and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.20.a6adeed.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.2--canary.20.a6adeed.0
  # or 
  yarn add tonic-minijs@1.0.2--canary.20.a6adeed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
