### PR TITLE
bugfix: Add ability to reset  mini

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,7 +1032,7 @@
           <script>
             showSelect = false
           </script>
-          <div class="p-4 border border-dashed border-black rounded mt-2">
+          <div class="p-4 border border-dashed border-black rounded mt-2" :clickout="showSelect = false">
             <div class="flex items-end">
               <div class="flex flex-col w-full">
                 <p class="font-bold font-mono text-sm">Custom Select:</p>
@@ -1089,6 +1089,35 @@
                           :class="selectedOption == 'Wade Cooper' ? 'font-semibold' : 'font-normal' "
                           class="block truncate"
                           >Wade Cooper</span
+                        >
+                        <span
+                          class="text-white absolute inset-y-0 right-0 flex items-center pr-4"
+                        >
+                          <svg
+                            class="h-5 w-5"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            aria-hidden="true"
+                          >
+                            <path
+                              fill-rule="evenodd"
+                              d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                              clip-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </li>
+                      <li
+                        :click="selectedOption = 'Dwight Schrute'"
+                        :class="selectedOption == 'Dwight Schrute' ? 'bg-indigo-600 text-white' : 'text-gray-900' "
+                        class="text-gray-900 relative cursor-default select-none py-2 pl-3 pr-9"
+                        id="listbox-option-0"
+                        role="option"
+                      >
+                        <span
+                          :class="selectedOption == 'Dwight Schrute' ? 'font-semibold' : 'font-normal' "
+                          class="block truncate"
+                          >Dwight Schrute</span
                         >
                         <span
                           class="text-white absolute inset-y-0 right-0 flex items-center pr-4"

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -43,6 +43,10 @@ export class Entity {
     return document.documentElement.contains(this.element)
   }
 
+  isEachEl() {
+    return this.element.hasAttribute(':each')
+  }
+
   isInsideEachEl() {
     if (this.element.hasAttribute(':each')) return false
     if (this.element.hasAttribute(':each.item')) return true
@@ -78,6 +82,17 @@ export class Entity {
       this.element.getAttribute(':each.item') === 'true' ||
       this.getClosestEl(':each.item')?.[':each.item'] === 'true'
     )
+  }
+
+  setEachItemTemplate() {
+    if (this.element.dataset.childTemplate) return
+    this.element.dataset.childTemplate = this.element.innerHTML
+  }
+
+  getEachItemTemplate() {
+    const template = document.createElement('template')
+    template.innerHTML = this.element.dataset.childTemplate
+    return template.content
   }
 
   getClosestEl(attr) {

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -85,14 +85,17 @@ export class Entity {
   }
 
   setEachItemTemplate() {
-    if (this.element.dataset.childTemplate) return
-    this.element.dataset.childTemplate = this.element.innerHTML
+    if (this.getEachItemTemplate()) return
+    const template = document.createElement('template')
+    template.innerHTML = this.element.innerHTML
+    template.id = "ChildTemplate:" + this.id
+    document.body.appendChild(template)
+    this.element.dataset.templateId = template.id
   }
 
   getEachItemTemplate() {
-    const template = document.createElement('template')
-    template.innerHTML = this.element.dataset.childTemplate
-    return template.content
+    const template = document.getElementById(this.element.dataset.templateId)
+    return template?.content
   }
 
   getClosestEl(attr) {

--- a/lib/entity/attributes.js
+++ b/lib/entity/attributes.js
@@ -278,7 +278,8 @@ export class Attributes {
 
     try {
       const items = await this._interpret(iterable)
-      this.childClone ||= this.entity.element.cloneNode(true).children
+      this.entity.setEachItemTemplate()
+      this.childClone ||= this.entity.getEachItemTemplate().children
 
       this.entity.element.innerHTML = ''
 

--- a/lib/entity/events.js
+++ b/lib/entity/events.js
@@ -149,16 +149,24 @@ export class Events {
     const listener = this.listener[attr]
     if (!listener) return
 
-    if (Array.isArray(listener)) {
-      listener.forEach(({ el, eventName, event }) => {
-        el.addEventListener(eventName, event)
+    [].concat(listener).forEach(({ el, eventName, event }) => {
+      el.addEventListener(eventName, (e) => {
+        this.debounce(() => {
+          event(e)
+        }, 50)
       })
-    } else {
-      const { el, eventName, event } = listener
-      el.addEventListener(eventName, event)
-    }
+    })
   }
 
+  debounce(callback, wait) {
+    if (this.timeout) return
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      callback()
+      this.timeout = null
+    }, wait)
+  }
+  
   setChangeEvent() {
     const el = this.entity.element
     const key = ':change'

--- a/lib/main.js
+++ b/lib/main.js
@@ -92,6 +92,13 @@ const MiniJS = (() => {
     console.error('Error initializing MiniJS:', error)
   })
 
+  // Reset MiniJS when the user navigates back
+  window.addEventListener('popstate', () => {
+    mini.reset().catch((error) => {
+      console.error('Error resetting MiniJS after navigation:', error);
+    });
+  });
+
   return {
     get debug() {
       return Mini.debug

--- a/lib/main.js
+++ b/lib/main.js
@@ -116,7 +116,7 @@ const MiniJS = (() => {
     },
     reset: async () => {
       await mini.reset()
-    },
+    }
   }
 })()
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -42,6 +42,12 @@ export class Mini {
     console.log(`MiniJS took ${executionTime}ms to run.`)
   }
 
+  async reset() {
+    this.observer.disconnect()
+    this.state.dispose()
+    await this.init()
+  }
+
   async _domReady() {
     return new Promise((resolve) => {
       if (document.readyState == 'loading') {
@@ -107,6 +113,9 @@ const MiniJS = (() => {
     },
     extendEvents: (events) => {
       mini.extensions.events.extend(events)
+    },
+    reset: async () => {
+      await mini.reset()
     },
   }
 })()

--- a/lib/state.js
+++ b/lib/state.js
@@ -35,7 +35,7 @@ export class State {
   }
 
   setProxyWindow() {
-    this.window ||= this.create(window)
+    this.window = this.create(window)
   }
 
   getEntityByElement(el, entities = Array.from(this.entities.values())) {

--- a/lib/state.js
+++ b/lib/state.js
@@ -297,4 +297,12 @@ export class State {
     const key = `${entityID}.${variable}`
     this.entityVariables.delete(key)
   }
+
+  dispose() {
+    Array.from(this.entities.values()).forEach((entity) => entity.dispose())
+    this.entities.clear()
+    this.variables.clear()
+    this.entityVariables.clear()
+    this.shouldUpdate = false
+  }
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -35,7 +35,7 @@ export class State {
   }
 
   setProxyWindow() {
-    this.window = this.create(window)
+    this.window ||= this.create(window)
   }
 
   getEntityByElement(el, entities = Array.from(this.entities.values())) {
@@ -299,10 +299,9 @@ export class State {
   }
 
   dispose() {
-    Array.from(this.entities.values()).forEach((entity) => entity.dispose())
-    this.entities.clear()
-    this.variables.clear()
-    this.entityVariables.clear()
     this.shouldUpdate = false
+    this.entities.clear()
+    this.entityVariables.clear()
+    this.variables.clear()
   }
 }


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.16--canary.25.faaaa70.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install tonic-minijs@1.0.16--canary.25.faaaa70.0
  # or 
  yarn add tonic-minijs@1.0.16--canary.25.faaaa70.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

## Changes
- Feature: Add MiniJS.reset() function.
  - This function clears all states, variables, and entities, and re-initializes MiniJS.
  
## Usage
```
  document.addEventListener("turbo:load", function(e) {
    MiniJS.reset()
  })
```
This ensures that MiniJS is reset whenever a Turbo event is triggered, maintaining a fresh state.



## About That Weird Issue
- Investigation Day 1 - https://www.loom.com/share/20169fed89ed4694a44b0e8f62589427?t=141&sid=b45c56c3-f10d-4314-b295-894c0080b2e7
- Investigation Day 2 - https://www.loom.com/share/fb6b1f9111ec40e796d2810dc80f0d6a?sid=7939bf82-e8d6-4e45-a0c1-4a5dc49d7772
